### PR TITLE
Set mountpoint via environment variable.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -6,7 +6,7 @@ require "rails/all"
 
 class PGHeroSolo < Rails::Application
   routes.append do
-    mount PgHero::Engine, at: "/"
+    mount PgHero::Engine, at: ENV['MOUNTPOINT'] || "/"
   end
 
   config.cache_classes = true


### PR DESCRIPTION
Allow setting the engine's mountpoint via environment variable to make life easier when running multiple containers in subdirectories behind nginx.
